### PR TITLE
Updated for Video and built-in to player

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 - PHP 5.3+ for closures
 - jQuery (enqueued by the plugin)
 
-This short handy plugin will add playback buttons to your audio elements added via the audio shortcode in WordPress. Each set of buttons is configured for it's corresponding audio element on the page, so you can adjust the speed of multiple files independantly. 
+This short handy plugin will add playback buttons to your audio and video elements added via the built-in wordpress shortcodes for media using mediaelement.js. Each set of buttons is configured for it's corresponding element on the page, so you can adjust the speed of multiple files independantly. 
 
-**CSS WILL NEED TO BE ADJUSTED.** I apply some very simple inline styles but I recommend you edit that out and create your own if you are using a beta version.
+There is currently no persistence implemented in this plugin. It just scratches an itch to be able to broadly adjust media playback speeds using the HTML api.
 
-Note: with my short round of testing, it seems only one audio file can play at a time via the default WordPress audio player, so keep that in mind. Clicking play on a second audio instance will pause the first. Your playback speed will be retained per audio tag.
+**NOTE:** This uses the HTML5 media Element API. Any browser not supporting these or using the Flash Player fallback will miss out on this functionality.
+
+Tested up to WordPress 4.9.1

--- a/media-playback-speed.php
+++ b/media-playback-speed.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Media Playback Speed
- * Description: Appends playback buttons to the Audio Media Player.
+ * Description: Appends playback buttons to the Media Player.
  * Author: Daron Spence
  * Version: 0.1
  */
@@ -12,12 +12,26 @@ add_action( 'wp_enqueue_scripts', function(){
 
 add_action( 'wp_footer', function(){
 ?>
+  <style>
+	.mejs-button.blank-button>button {
+		background: transparent;
+		color: #ccc;
+		font-size: 1em;
+		width: auto;
+	}
+	</style>
 	<script type="text/template" id="playback-buttons-template">
-		<div class="playback-speed-buttons-wrap" style="margin-top: 2em;">
-			<button onclick="MPSchangePbRate(0.5, this )">.5x</button>
-			<button onclick="MPSchangePbRate(1.0, this )">1x</button>
-			<button onclick="MPSchangePbRate(2.0, this )">2x</button>
-			<button onclick="MPSchangePbRate(4.0, this )">4x</button>
+		<div class="mejs-button blank-button">
+			<button type="button" class="playback-rate-button" data-value="0.5" title="Playback Speed 0.5x" aria-label="Playback Speed 0.5x" tabindex="0">.5x</button>
+		</div>
+		<div class="mejs-button blank-button">
+			<button type="button" class="playback-rate-button" data-value="1" title="Playback Speed 1x" aria-label="Playback Speed 1x" tabindex="0">1x</button>
+		</div>
+		<div class="mejs-button blank-button">
+			<button type="button" class="playback-rate-button" data-value="1.5" title="Playback Speed 1.5x" aria-label="Playback Speed 1.5x" tabindex="0">1.5x</button>
+		</div>
+		<div class="mejs-button blank-button">
+			<button type="button" class="playback-rate-button" data-value="2" title="Playback Speed 2x" aria-label="Playback Speed 2x" tabindex="0">2x</button>
 		</div>
 	</script>
 	<script type="text/javascript">
@@ -25,22 +39,25 @@ add_action( 'wp_footer', function(){
 			$(window).load( function(){
 
 				var $buttons = $( $("#playback-buttons-template").html() );
-				var $els = $( 'audio.wp-audio-shortcode' );
+				var $els = $( '.mejs-container' );
 
 				for ( i = 0; i < $els.length; i++ ){
-					$buttons.find('button').attr('data-audio-el', $els[i].id );
-					$( $els[i] ).after( $buttons.clone() );
+					var audioTag = $( $els[i] ).find('audio,video')[0];
+					$buttons.find('.playback-rate-button').attr('aria-controls', audioTag.id );
+					var $controls = $( $els[i] ).find('.mejs-controls');
+					if($controls.length > 0) {
+						$controls.find('.mejs-duration-container').after( $buttons.clone() );
+					}
 				}
+				$('body').on('click', '.playback-rate-button', function() {
+					var btnEl = $(this),
+							mediaTag = $('#'+btnEl.attr('aria-controls'))[0],
+							rate = btnEl.attr('data-value');
+					mediaTag.setPlaybackRate(rate);
+				});
 
 			});
 		})(jQuery);
-
-		function MPSchangePbRate( rate, el ){
-			
-			var audioTag = jQuery('#' + jQuery( el ).attr('data-audio-el') )[0];
-			audioTag.playbackRate = rate;
-
-		}
 	</script>
 <?php
 }, 1, 100 );


### PR DESCRIPTION
* Updates to work with audio or video elements.
* no more `onclick=""`, we bind the event handler to body and filter by a specific class we add to these buttons. 
* We use aria elements (I'm hoping this makes accessible)
* Due to binding on body, manual media controls can be added at arbitrary position(s) in DOM
* Updated Readme
* Tested on WordPress 4.9